### PR TITLE
Removes bind method to avoid React warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ class App extends Component {
         <Pagination 
           activePage={this.state.activePage} 
           totalItemsCount={450} 
-          onChange={this.handlePageChange.bind(this)}
+          onChange={this.handlePageChange}
         />
       </div>
     );


### PR DESCRIPTION
Using `.bind()` triggers console warnings in newer versions of React that suggest removing the method. The pagination component seems to continue to work perfectly even after removing this.