### PR TITLE
Feature/support override element

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ class App extends Component {
           totalItemsCount={450} 
           pageRangeDisplayed={5}
           onChange={this.handlePageChange}
+          nextPage={{text: (<IconSprite name="next-page"/>), overrideElement: false}}
         />
       </div>
     );
@@ -68,10 +69,10 @@ Name | Type | Default | Description
 `acivePage` | Number | `1` | Active page
 `itemsCountPerPage` | Number | `10` | Count of items per  page
 `pageRangeDisplayed` | Number | `5` | Range of pages in paginator, exclude navigation blocks (prev, next, first, last pages)
-`firstPageText` | String / ReactElement | `«` | Text of first page navigation button or whole element
-`lastPageText` | String / ReactElement | `»` | Text of last page navigation button or whole element
-`prevPageText` | String / ReactElement | `⟨` | Text of prev page navigation button or whole element
-`nextPageText` | String / ReactElement | `⟩` | Text of next page navigation button or whole element
+`firstPage` | String / Object | `«` | Text of first page navigation button or whole element, you can override the entire element by passing a setting object: `{text: (<IconSprite name="next-page"/>), overrideElement: false}`
+`lastPage` | String / Object | `»` | Text of last page navigation button or whole element, you can override the entire element by passing a setting object: `{text: (<IconSprite name="next-page"/>), overrideElement: false}`
+`prevPage` | String / Object | `⟨` | Text of prev page navigation button or whole element, you can override the entire element by passing a setting object: `{text: (<IconSprite name="next-page"/>), overrideElement: false}`
+`nextPage` | String / Object | `⟩` | Text of next page navigation button or whole element, you can override the entire element by passing a setting object: `{text: (<IconSprite name="next-page"/>), overrideElement: false}`
 `innerClass` | String | `pagination` | Class name of `<ul>` tag
 `activeClass` | String | `active` | Class name of `<li>` active tag
 

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -7,6 +7,7 @@ export default class Page extends Component {
             PropTypes.string,
             PropTypes.element
         ]),
+        overrideElement: PropTypes.bool,
         pageNumber: PropTypes.number.isRequired,
         onClick: PropTypes.func.isRequired,
         isActive: PropTypes.bool.isRequired
@@ -16,7 +17,7 @@ export default class Page extends Component {
         const text = this.props.pageText || this.props.pageNumber;
         const activeClass = this.props.activeClass || "active";
 
-        if (React.isValidElement(text)) {
+        if (React.isValidElement(text) && this.props.overrideElement) {
             return text;
         }
 

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -9,21 +9,21 @@ export default class Pagination extends React.Component {
       activePage: PropTypes.number,
       pageRangeDisplayed: PropTypes.number,
       itemsCountPerPage: PropTypes.number,
-      prevPageText: PropTypes.oneOfType([
+      prevPage: PropTypes.oneOfType([
         PropTypes.string,
-        PropTypes.element
+        PropTypes.object
       ]),
-      nextPageText: PropTypes.oneOfType([
+      nextPage: PropTypes.oneOfType([
         PropTypes.string,
-        PropTypes.element
+        PropTypes.object
       ]),
-      lastPageText: PropTypes.oneOfType([
+      lastPage: PropTypes.oneOfType([
         PropTypes.string,
-        PropTypes.element
+        PropTypes.object
       ]),
-      firstPageText: PropTypes.oneOfType([
+      firstPage: PropTypes.oneOfType([
         PropTypes.string,
-        PropTypes.element
+        PropTypes.object
       ]),
       innerClass: PropTypes.string
     }
@@ -32,10 +32,10 @@ export default class Pagination extends React.Component {
       itemsCountPerPage: 10,
       pageRangeDisplayed: 5,
       activePage: 1,
-      prevPageText: "⟨",
-      firstPageText: "«",
-      nextPageText: "⟩",
-      lastPageText: "»",
+      prevPage: {text: "⟨", overrideElement: false},
+      firstPage: {text: "«", overrideElement: false},
+      nextPage: {text: "⟩", overrideElement: false},
+      lastPage: {text: "»", overrideElement: false},
       innerClass: "pagination",
     }
 
@@ -45,10 +45,10 @@ export default class Pagination extends React.Component {
             itemsCountPerPage,
             pageRangeDisplayed,
             activePage,
-            prevPageText,
-            nextPageText,
-            firstPageText,
-            lastPageText,
+            prevPage,
+            nextPage,
+            firstPage,
+            lastPage,
             totalItemsCount,
             onChange,
             activeClass
@@ -74,10 +74,11 @@ export default class Pagination extends React.Component {
         paginationInfo.has_previous_page && pages.unshift(
             <Page
                 isActive={false}
-                key={"prev" + paginationInfo.previous_page}
+                key={"prev"}
                 pageNumber={paginationInfo.previous_page}
                 onClick={onChange}
-                pageText={prevPageText}
+                pageText={prevPage.text}
+                overrideElement={prevPage.overrideElement}
             />
         );
 
@@ -87,17 +88,18 @@ export default class Pagination extends React.Component {
                 key={1}
                 pageNumber={1}
                 onClick={onChange}
-                pageText={firstPageText}
+                pageText={firstPage.text}
+                overrideElement={firstPage.overrideElement}
             />
         );
-
         paginationInfo.has_next_page && pages.push(
             <Page
                 isActive={false}
-                key={"next" + paginationInfo.next_page}
+                key={"next"}
                 pageNumber={paginationInfo.next_page}
                 onClick={onChange}
-                pageText={nextPageText}
+                pageText={nextPage.text}
+                overrideElement={nextPage.overrideElement}
             />
         );
 
@@ -107,10 +109,11 @@ export default class Pagination extends React.Component {
                 key={paginationInfo.total_pages}
                 pageNumber={paginationInfo.total_pages}
                 onClick={onChange}
-                pageText={lastPageText}
+                pageText={lastPage.text}
+                overrideElement={lastPage.overrideElement}
             />
         );
-
+        
         return pages;
     }
 


### PR DESCRIPTION
A feature added that you can override the entire element by passing a setting object: `{text: (<IconSprite name="next-page"/>), overrideElement: false}`