### PR TITLE
Propagate disabledClass to the first, previous, next and last Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,5 @@ Name | Type | Default | Description
 `nextPageText` | String / ReactElement | `⟩` | Text of next page navigation button
 `innerClass` | String | `pagination` | Class name of `<ul>` tag
 `activeClass` | String | `active` | Class name of active `<li>` tag
+`disabledClass` | String | `disabled` | Class name of the first, previous, next and last `<li>` tags when disabled
 `hideDisabled` | Boolean | `false` | Hide navigation buttons (prev page, next page) if they are disabled.

--- a/dist/Pagination.js
+++ b/dist/Pagination.js
@@ -50,6 +50,7 @@ var Pagination = function (_React$Component) {
                 totalItemsCount = _props.totalItemsCount,
                 onChange = _props.onChange,
                 activeClass = _props.activeClass,
+                disabledClass = _props.disabledClass,
                 hideDisabled = _props.hideDisabled;
 
 
@@ -73,7 +74,8 @@ var Pagination = function (_React$Component) {
                 pageNumber: paginationInfo.previous_page,
                 onClick: onChange,
                 pageText: prevPageText,
-                isDisabled: !paginationInfo.has_previous_page
+                isDisabled: !paginationInfo.has_previous_page,
+                disabledClass: disabledClass
             }));
 
             hideDisabled && !paginationInfo.has_previous_page || pages.unshift(_react2.default.createElement(_Page2.default, {
@@ -81,7 +83,8 @@ var Pagination = function (_React$Component) {
                 pageNumber: 1,
                 onClick: onChange,
                 pageText: firstPageText,
-                isDisabled: paginationInfo.current_page === paginationInfo.first_page
+                isDisabled: paginationInfo.current_page === paginationInfo.first_page,
+                disabledClass: disabledClass
             }));
 
             hideDisabled && !paginationInfo.has_next_page || pages.push(_react2.default.createElement(_Page2.default, {
@@ -89,7 +92,8 @@ var Pagination = function (_React$Component) {
                 pageNumber: paginationInfo.next_page,
                 onClick: onChange,
                 pageText: nextPageText,
-                isDisabled: !paginationInfo.has_next_page
+                isDisabled: !paginationInfo.has_next_page,
+                disabledClass: disabledClass
             }));
 
             hideDisabled && !paginationInfo.has_next_page || pages.push(_react2.default.createElement(_Page2.default, {
@@ -97,7 +101,8 @@ var Pagination = function (_React$Component) {
                 pageNumber: paginationInfo.total_pages,
                 onClick: onChange,
                 pageText: lastPageText,
-                isDisabled: paginationInfo.current_page === paginationInfo.total_pages
+                isDisabled: paginationInfo.current_page === paginationInfo.total_pages,
+                disabledClass: disabledClass
             }));
 
             return pages;
@@ -129,6 +134,7 @@ Pagination.propTypes = {
     firstPageText: _react.PropTypes.oneOfType([_react.PropTypes.string, _react.PropTypes.element]),
     innerClass: _react.PropTypes.string,
     activeClass: _react.PropTypes.string,
+    disabledClass: _react.PropTypes.string,
     hideDisabled: _react.PropTypes.bool
 };
 Pagination.defaultProps = {

--- a/src/components/Pagination-test.js
+++ b/src/components/Pagination-test.js
@@ -47,5 +47,22 @@ describe("<Pagination />", () => {
       expect(wrapper.find("ul").hasClass("center-block")).to.be.true;
       expect(wrapper.find("ul").hasClass("text-center")).to.be.true;
     });
+
+    it("passes down disabledClass to the prev, first, next and last pages", () => {
+      const disabledClass="somethingElse";
+      const wrapper = mount(
+        <Pagination {...props} hideDisabled={false} totalItemsCount={1} disabledClass={disabledClass} />
+      );
+      const innerUl = wrapper.find("ul");
+      const firstPage = innerUl.childAt(0);
+      const prevPage = innerUl.childAt(1);
+      const nextPage = innerUl.childAt(2);
+      const lastPage = innerUl.childAt(3);
+
+      expect(firstPage.hasClass(disabledClass)).to.be.true;
+      expect(prevPage.hasClass(disabledClass)).to.be.true;
+      expect(nextPage.hasClass(disabledClass)).to.be.true;
+      expect(lastPage.hasClass(disabledClass)).to.be.true;
+    });
   });
 });

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -27,6 +27,7 @@ export default class Pagination extends React.Component {
       ]),
       innerClass: PropTypes.string,
       activeClass: PropTypes.string,
+      disabledClass: PropTypes.string,
       hideDisabled: PropTypes.bool
     }
 
@@ -54,6 +55,7 @@ export default class Pagination extends React.Component {
             totalItemsCount,
             onChange,
             activeClass,
+            disabledClass,
             hideDisabled
         } = this.props;
 
@@ -82,6 +84,7 @@ export default class Pagination extends React.Component {
                 onClick={onChange}
                 pageText={prevPageText}
                 isDisabled={!paginationInfo.has_previous_page}
+                disabledClass={disabledClass}
             />
         );
 
@@ -92,6 +95,7 @@ export default class Pagination extends React.Component {
                 onClick={onChange}
                 pageText={firstPageText}
                 isDisabled={paginationInfo.current_page === paginationInfo.first_page}
+                disabledClass={disabledClass}
             />
         );
 
@@ -102,6 +106,7 @@ export default class Pagination extends React.Component {
                 onClick={onChange}
                 pageText={nextPageText}
                 isDisabled={!paginationInfo.has_next_page}
+                disabledClass={disabledClass}
             />
         );
 
@@ -112,6 +117,7 @@ export default class Pagination extends React.Component {
                 onClick={onChange}
                 pageText={lastPageText}
                 isDisabled={paginationInfo.current_page === paginationInfo.total_pages}
+                disabledClass={disabledClass}
             />
         );
 


### PR DESCRIPTION
I noticed the `disabledClass` prop was added to the `Page`, but `Pagination` was not passing it down.
I also updated the README, now it describes the `disableClass` prop.