### PR TITLE
Ellipsis support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,5 @@ Name | Type | Default | Description
 `linkClassPrev` | String | | Class of the previous `<a>` tag
 `linkClassNext` | String | | Class of the next `<a>` tag
 `linkClassLast` | String | | Class of the last `<a>` tag
+`ellipsis` | Boolean | `false` | Put links to the first/last page along with an ellipsis if they are out of the page range
+`ellipsisText` | String / ReactElement | `…` | Text of ellipsis element

--- a/src/components/Ellipsis.js
+++ b/src/components/Ellipsis.js
@@ -1,0 +1,39 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import cx from "classnames";
+
+export default class Ellipsis extends Component {
+    static propTypes = {
+        ellipsisText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+        disabledClass: PropTypes.string,
+        itemClass: PropTypes.string,
+        linkClass: PropTypes.string
+    };
+
+    static defaultProps = {
+        ellipsisText: "…",
+        disabledClass: "disabled",
+        itemClass: undefined,
+        linkClass: undefined
+    };
+
+    render() {
+        let {
+            ellipsisText,
+            itemClass,
+            disabledClass,
+            linkClass
+        } = this.props;
+
+        const css = cx(itemClass, disabledClass);
+        const linkCss = cx(linkClass);
+
+        return (
+            <li className={css}>
+                <a className={linkCss} href="#" onClick={(event) => event.preventDefault()}>
+                    {ellipsisText}
+                </a>
+            </li>
+        );
+    }
+}

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -22,7 +22,7 @@ export default class Page extends Component {
         disabledClass: "disabled",
         itemClass: undefined,
         linkClass: undefined,
-        activeLinkCLass: undefined,
+        activeLinkClass: undefined,
         isActive: false,
         isDisabled: false,
         href: "#"

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import paginator from "paginator";
 import Page from "./Page";
+import Ellipsis from "./Ellipsis";
 import cx from "classnames";
 
 export default class Pagination extends React.Component {
@@ -32,7 +33,9 @@ export default class Pagination extends React.Component {
     linkClassNext: PropTypes.string,
     linkClassLast: PropTypes.string,
     hideFirstLastPages: PropTypes.bool,
-    getPageUrl: PropTypes.func
+    getPageUrl: PropTypes.func,
+    ellipsis: PropTypes.bool,
+    ellipsisText: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
   };
 
   static defaultProps = {
@@ -48,7 +51,8 @@ export default class Pagination extends React.Component {
     linkClass: undefined,
     activeLinkClass: undefined,
     hideFirstLastPages: false,
-    getPageUrl: (i) => "#"
+    getPageUrl: (i) => "#",
+    ellipsisText: "…"
   };
 
   isFirstPageVisible(has_previous_page) {
@@ -103,13 +107,44 @@ export default class Pagination extends React.Component {
       linkClassNext,
       linkClassLast,
       hideFirstLastPages,
-      getPageUrl
+      getPageUrl,
+      ellipsis,
+      ellipsisText
     } = this.props;
 
     const paginationInfo = new paginator(
       itemsCountPerPage,
       pageRangeDisplayed
     ).build(totalItemsCount, activePage);
+
+    if (ellipsis && paginationInfo.first_page > 1) {
+      pages.push(
+        <Page
+          isActive={1 === activePage}
+          key={1}
+          href={getPageUrl(1)}
+          pageNumber={1}
+          pageText={"1"}
+          onClick={onChange}
+          itemClass={itemClass}
+          linkClass={linkClass}
+          activeClass={activeClass}
+          activeLinkClass={activeLinkClass}
+        />
+      );
+
+      if (paginationInfo.first_page > 2) {
+        pages.push(
+          <Ellipsis
+            key="startEllipsis"
+            itemClass={itemClass}
+            linkClass={linkClass}
+            disabledClass={disabledClass}
+            ellipsisText={ellipsisText}
+          />
+        );
+      }
+    }
 
     for (
       let i = paginationInfo.first_page;
@@ -132,7 +167,36 @@ export default class Pagination extends React.Component {
       );
     }
 
-    this.isPrevPageVisible(paginationInfo.has_previous_page) && 
+    if (ellipsis && paginationInfo.last_page < paginationInfo.total_pages) {
+      if (paginationInfo.last_page < paginationInfo.total_pages - 1) {
+        pages.push(
+          <Ellipsis
+            key="endEllipsis"
+            itemClass={itemClass}
+            linkClass={linkClass}
+            disabledClass={disabledClass}
+            ellipsisText={ellipsisText}
+          />
+        );
+      }
+
+      pages.push(
+        <Page
+          isActive={paginationInfo.total_pages === activePage}
+          key={paginationInfo.total_pages}
+          href={getPageUrl(paginationInfo.total_pages)}
+          pageNumber={paginationInfo.total_pages}
+          pageText={paginationInfo.total_pages + ""}
+          onClick={onChange}
+          itemClass={itemClass}
+          linkClass={linkClass}
+          activeClass={activeClass}
+          activeLinkClass={activeLinkClass}
+        />
+      );
+    }
+
+    this.isPrevPageVisible(paginationInfo.has_previous_page) &&
       pages.unshift(
         <Page
           key={"prev" + paginationInfo.previous_page}
@@ -146,7 +210,7 @@ export default class Pagination extends React.Component {
         />
       );
 
-    this.isFirstPageVisible(paginationInfo.has_previous_page) && 
+    this.isFirstPageVisible(paginationInfo.has_previous_page) &&
       pages.unshift(
         <Page
           key={"first"}

--- a/src/example/App.js
+++ b/src/example/App.js
@@ -84,6 +84,20 @@ export default class App extends Component {
   );
 }`;
 
+    const ellipsis = `render() {
+  return (
+    <Pagination
+      ellipsis
+      hideFirstLastPages
+      pageRangeDisplayed={10}
+      activePage={this.state.activePage}
+      itemsCountPerPage={PER_PAGE}
+      totalItemsCount={TOTAL_COUNT}
+      onChange={this.handlePageChange}
+    />
+  );
+}`;
+
     const overrideText = `render() {
   return (
     <Pagination
@@ -252,6 +266,28 @@ export default class App extends Component {
             <SyntaxHighlighter language='javascript' style={sunburst}>{hideFirstLastPages}</SyntaxHighlighter>
             <div className='text-center'>
               <Pagination
+                hideFirstLastPages
+                pageRangeDisplayed={10}
+                activePage={this.state.activePage}
+                itemsCountPerPage={PER_PAGE}
+                totalItemsCount={TOTAL_COUNT}
+                onChange={this.handlePageChange}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="panel panel-default">
+          <div className="panel-heading">
+            <a href='#ellipsis'>
+              <h4 id='nav-arrows'>Ellipsis</h4>
+            </a>
+          </div>
+          <div className="panel-body">
+            <SyntaxHighlighter language='javascript' style={sunburst}>{ellipsis}</SyntaxHighlighter>
+            <div className='text-center'>
+              <Pagination
+                ellipsis
                 hideFirstLastPages
                 pageRangeDisplayed={10}
                 activePage={this.state.activePage}


### PR DESCRIPTION
This PR adds the ability to include the first and/or last page when they wouldn't appear normally in the range, along with an ellipsis (...).  The text of the ellipsis element can be customized, and the element will use the normal classes for items and disabled links that the rest of the Pagination component will be using.

![screenshot 2018-11-09 08 32 32](https://user-images.githubusercontent.com/7477/48275306-07621e00-e3fa-11e8-92c8-da6193cf09af.png)