### PR TITLE
Add Events for Previous, Next, First, and Last Page Clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Name | Type | Default | Description
 --- | --- | --- | --- |
 `totalItemsCount` | Number | | **Required.** Total count of items which you are going to display
 `onChange` | Function | | **Required.** Page change handler. Receive pageNumber as arg
+`onPrevPage` | Function | | Will fire in addition to onChange if the previous page button is clicked.
+`onNextPage` | Function | | Will fire in addition to onChange if the next page button is clicked.
+`onFirstPage` | Function | | Will fire in addition to onChange if the first page button is clicked.
+`onLastPage` | Function | | Will fire in addition to onChange if the last page button is clicked.
 `activePage` | Number | `1` | **Required.** Active page
 `itemsCountPerPage` | Number | `10` | Count of items per  page
 `pageRangeDisplayed` | Number | `5` | Range of pages in paginator, exclude navigation blocks (prev, next, first, last pages)

--- a/dist/Page.js
+++ b/dist/Page.js
@@ -53,14 +53,30 @@ function (_Component) {
     value: function handleClick(e) {
       var _this$props = this.props,
           isDisabled = _this$props.isDisabled,
-          pageNumber = _this$props.pageNumber;
+          pageNumber = _this$props.pageNumber,
+          key = _this$props.key,
+          onNextPage = _this$props.onNextPage,
+          onPrevPage = _this$props.onPrevPage,
+          onFirstPage = _this$props.onFirstPage,
+          onLastPage = _this$props.onLastPage,
+          onClick = _this$props.onClick;
       e.preventDefault();
 
       if (isDisabled) {
         return;
       }
 
-      this.props.onClick(pageNumber);
+      onClick(pageNumber);
+
+      if (key.indexOf('prev') > -1) {
+        onPrevPage && onPrevPage(e, pageNumber);
+      } else if (key.indexOf('next') > -1) {
+        onNextPage && onNextPage(e, pageNumber);
+      } else if (key.indexOf('first') > -1) {
+        onFirstPage && onFirstPage(e, pageNumber);
+      } else if (key.indexOf('last') > -1) {
+        onLastPage && onLastPage(e, pageNumber);
+      }
     }
   }, {
     key: "render",

--- a/dist/Pagination.js
+++ b/dist/Pagination.js
@@ -207,6 +207,10 @@ exports["default"] = Pagination;
 _defineProperty(Pagination, "propTypes", {
   totalItemsCount: _propTypes["default"].number.isRequired,
   onChange: _propTypes["default"].func.isRequired,
+  onNextPage: _propTypes["default"].func,
+  onPrevPage: _propTypes["default"].func,
+  onFirstPage: _propTypes["default"].func,
+  onLastPage: _propTypes["default"].func,
   activePage: _propTypes["default"].number,
   itemsCountPerPage: _propTypes["default"].number,
   pageRangeDisplayed: _propTypes["default"].number,

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -29,12 +29,30 @@ export default class Page extends Component {
     };
 
     handleClick(e) {
-        const { isDisabled, pageNumber } = this.props;
+        const {
+            isDisabled,
+            pageNumber,
+            key,
+            onNextPage,
+            onPrevPage,
+            onFirstPage,
+            onLastPage,
+            onClick
+        } = this.props;
         e.preventDefault();
         if (isDisabled) {
             return;
         }
-        this.props.onClick(pageNumber);
+        onClick(pageNumber);
+        if (key.indexOf('prev') > -1) {
+            onPrevPage && onPrevPage(e, pageNumber)
+        } else if (key.indexOf('next') > -1) {
+            onNextPage && onNextPage(e, pageNumber)
+        } else if (key.indexOf('first') > -1) {
+            onFirstPage && onFirstPage(e, pageNumber)
+        } else if (key.indexOf('last') > -1) {
+            onLastPage && onLastPage(e, pageNumber)
+        }
     }
 
     render() {

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -8,6 +8,10 @@ export default class Pagination extends React.Component {
   static propTypes = {
     totalItemsCount: PropTypes.number.isRequired,
     onChange: PropTypes.func.isRequired,
+    onNextPage: PropTypes.func,
+    onPrevPage: PropTypes.func,
+    onFirstPage: PropTypes.func,
+    onLastPage: PropTypes.func,
     activePage: PropTypes.number,
     itemsCountPerPage: PropTypes.number,
     pageRangeDisplayed: PropTypes.number,


### PR DESCRIPTION
This PR adds events for different page events.

`function(event, pageNumber)`

`onPrevPage` | Function | | Will fire in addition to onChange if the previous page button is clicked.
`onNextPage` | Function | | Will fire in addition to onChange if the next page button is clicked.
`onFirstPage` | Function | | Will fire in addition to onChange if the first page button is clicked.
`onLastPage` | Function | | Will fire in addition to onChange if the last page button is clicked.